### PR TITLE
On-demand SSL certs for different hostnames

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -325,6 +325,7 @@ mkdir -p /etc/caddy
 cat >/etc/caddy/Caddyfile <<CADDY
 {
   email admin@example.com
+  auto_https disable_redirects
 }
 
 # HTTPS on 443 with Caddy internal TLS

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -325,12 +325,13 @@ mkdir -p /etc/caddy
 cat >/etc/caddy/Caddyfile <<CADDY
 {
   email admin@example.com
-  auto_https disable_redirects
 }
 
 # HTTPS on 443 with Caddy internal TLS
-${EVCC_HOSTNAME}.local:443 {
-  tls internal
+https:// {
+  tls internal {
+    on_demand
+  }
   encode zstd gzip
   log
   reverse_proxy 127.0.0.1:7070


### PR DESCRIPTION
Caddyfile angepasst
- Direktive auto_https disable_redirects entfernt, um die Anwenderfreundlichkeit zu erhöhen
- statt auf evcc.local lauscht Caddy jetzt auf https:// (also alle) und erzeugt mit tls internal { on_demand } auch gleich die passenden Zertifikate

resolves #3 