### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Create Release
 
+permissions:
+  contents: write
+
 on:
   schedule:
     # Run every Monday at 2am UTC


### PR DESCRIPTION
Potential fix for [https://github.com/evcc-io/images/security/code-scanning/2](https://github.com/evcc-io/images/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that grants only what this workflow needs. Since it creates releases and uploads assets, it requires write access to repository contents, but nothing suggests it needs broader scopes such as `issues`, `pull-requests`, or `actions`. The simplest and safest fix is to set `permissions` at the workflow root so it applies to all jobs, with `contents: write` (or, if you prefer stricter scoping later, split permissions per job). This avoids any change in behavior while preventing GitHub from falling back to potentially broader repository defaults.

Concretely for `.github/workflows/release.yml`, add a `permissions:` block right after the `name:` line (before `on:`). Use:
```yaml
permissions:
  contents: write
```
This is the minimal permission needed for creating and modifying releases and uploading assets using `GITHUB_TOKEN`. No imports or other definitions are needed; this is purely a YAML workflow configuration change. No other parts of the workflow need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
